### PR TITLE
Added non-standard person count analysis.

### DIFF
--- a/inst/csv/achilles/achilles_analysis_details.csv
+++ b/inst/csv/achilles/achilles_analysis_details.csv
@@ -49,6 +49,7 @@ ANALYSIS_ID,DISTRIBUTION,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_
 230,0,,Number of visit_occurrence records inside valid observation period,,,,,,0,Observation Period
 231,0,,Proportion of people with at least one visit_occurrence record outside a valid observation period,Proportion,Number of people with a visit_occurrence record outside a valid observation period,Number of people in visit_occurrence,,,0,Observation Period
 232,0,,Proportion of visit_occurrence records outside a valid observation period,Proportion,Number of visit_occurrence records outside a valid observation period,Number of visit_occurrence records,,,0,Observation Period
+240,0,,"Number of persons with at least one visit occurrence, by visit_source_concept_id",visit_source_concept_id,,,,,1,Visit Occurrence
 300,0,,Number of providers,,,,,,1,Provider
 301,0,,Number of providers by specialty concept_id,specialty_concept_id,,,,,1,Provider
 303,0,,Number of providers records by specialty_concept_id and visit_concept_id,specialty_concept_id,visit_concept_id,,,,1,Provider
@@ -74,6 +75,7 @@ ANALYSIS_ID,DISTRIBUTION,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_
 430,0,,Number of condition_occurrence records inside a valid observation period,,,,,,0,Observation Period
 431,0,,Proportion of people with at least one condition_occurrence record outside a valid observation period,Proportion,Number of people with a condition_occurrence record outside a valid observation period,Number of people in condition_occurrence,,,0,Observation Period
 432,0,,Proportion of condition_occurrence records outside a valid observation period,Proportion,Number of condition_occurrence records outside a valid observation period,Number of condition_occurrence records,,,0,Observation Period
+440,0,,"Number of persons with at least one condition occurrence, by condition_source_concept_id",condition_source_concept_id,,,,,1,Condition Occurrence
 500,0,,"Number of persons with death, by cause_concept_id",cause_concept_id,,,,,1,Death
 501,0,,"Number of records of death, by cause_concept_id",cause_concept_id,,,,,1,Death
 502,0,,Number of persons by death month,calendar month,,,,,1,Death
@@ -91,6 +93,7 @@ ANALYSIS_ID,DISTRIBUTION,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_
 530,0,,Number of death records inside a valid observation period,,,,,,0,Observation Period
 531,0,,Proportion of people with at least one death record outside a valid observation period,Proportion,Number of people with a death record outside a valid observation period,Number of people in death,,,0,Observation Period
 532,0,,Proportion of death records that occur outside a valid observation period,Proportion,Number of records in death outside a valid observation period,Number of death records,,,0,Observation Period
+540,0,,"Number of persons with death, by cause_source_concept_id",cause_source_concept_id,,,,,1,Death
 600,0,,"Number of persons with at least one procedure occurrence, by procedure_concept_id",procedure_concept_id,,,,,1,Procedure Occurrence
 601,0,,"Number of procedure occurrence records, by procedure_concept_id",procedure_concept_id,,,,,1,Procedure Occurrence
 602,0,,"Number of persons by procedure occurrence start month, by procedure_concept_id",procedure_concept_id,calendar month,,,,1,Procedure Occurrence
@@ -108,6 +111,7 @@ ANALYSIS_ID,DISTRIBUTION,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_
 630,0,,Number of procedure_occurrence records inside a valid observation period,,,,,,1,Observation Period
 631,0,,Proportion of people with at least one procedure_occurrence record outside a valid observation period,Proportion,Number of people with a procedure_occurrence record outside a valid observation period,Number of people in procedure_occurrence,,,0,Observation Period
 632,0,,Proportion of procedure_occurrence records outside a valid observation period,Proportion,Number of records in procedure_occurrence outside a valid observation period,Number of procedure_occurrence records,,,0,Observation Period
+640,0,,"Number of persons with at least one procedure occurrence, by procedure_source_concept_id",procedure_source_concept_id,,,,,1,Procedure Occurrence
 691,0,,Percentage of total persons that have at least x procedures,procedure_concept_id,procedure_person,,,,1,Procedure Occurrence
 700,0,,"Number of persons with at least one drug exposure, by drug_concept_id",drug_concept_id,,,,,1,Drug Exposure
 701,0,,"Number of drug exposure records, by drug_concept_id",drug_concept_id,,,,,1,Drug Exposure
@@ -130,6 +134,7 @@ ANALYSIS_ID,DISTRIBUTION,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_
 730,0,,Number of drug_exposure records inside a valid observation period,,,,,,0,Observation Period
 731,0,,Proportion of people with at least one drug_exposure record outside a valid observation period,Proportion,Number of people with a drug_exposure record outside a valid observation period,Number of people in drug_exposure,,,0,Observation Period
 732,0,,Proportion of drug_exposure records outside a valid observation period,Proportion,Number of records in drug_exposure outside a valid observation period,Number of drug_exposure records,,,0,Observation Period
+740,0,,"Number of persons with at least one drug exposure, by drug_source_concept_id",drug_source_concept_id,,,,,1,Drug Exposure
 791,0,,Percentage of total persons that have at least x drug exposures,drug_concept_id,drug_person,,,,1,Drug Exposure
 800,0,,"Number of persons with at least one observation occurrence, by observation_concept_id",observation_concept_id,,,,,1,Observation
 801,0,,"Number of observation occurrence records, by observation_concept_id",observation_concept_id,,,,,1,Observation
@@ -155,6 +160,7 @@ ANALYSIS_ID,DISTRIBUTION,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_
 830,0,,Number of observation records inside a valid observation period,,,,,,0,Observation Period
 831,0,,Proportion of people with at least one observation record outside a valid observation period,Proportion,Number of people with a observation record outside a valid observation period,Number of people in observation,,,0,Observation Period
 832,0,,Proportion of observation records outside a valid observation period,Proportion,Number of records in observation outside a valid observation period,Number of observation records,,,0,Observation Period
+840,0,,"Number of persons with at least one observation occurrence, by observation_source_concept_id",observation_source_concept_id,,,,,1,Observation
 891,0,,Percentage of total persons that have at least x observations,observation_concept_id,observation_person,,,,1,Observation
 900,0,,"Number of persons with at least one drug era, by drug_concept_id",drug_concept_id,,,,,1,Drug Era
 901,0,,"Number of drug era records, by drug_concept_id",drug_concept_id,,,,,1,Drug Era
@@ -211,6 +217,7 @@ ANALYSIS_ID,DISTRIBUTION,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_
 1330,0,,Number of visit_detail records inside a valid observation period,,,,,,0,Observation Period
 1331,0,,Proportion of people with at least one visit_detail record outside a valid observation period,Proportion,Number of people with a visit_detail record outside a valid observation period,Number of people in visit_detail,,,0,Observation Period
 1332,0,,Proportion of visit_detail records outside a valid observation period,Proportion,Number of records in visit_detail outside a valid observation period,Number of visit_detail records,,,0,Observation Period
+1340,0,,"Number of persons with at least one visit detail, by visit_detail_source_concept_id",visit_detail_source_concept_id,,,,,1,Visit Detail
 1406,1,,Length of payer plan (days) of first payer plan period by gender,gender_concept_id,,,,,1,Payer Plan Period
 1407,1,,Length of payer plan (days) of first payer plan period by age decile,age_decile,,,,,1,Payer Plan Period
 1408,0,,"Number of persons by length of payer plan period, in 30d increments",payer plan period length 30d increments,,,,,1,Payer Plan Period
@@ -271,6 +278,7 @@ ANALYSIS_ID,DISTRIBUTION,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_
 1831,0,,Proportion of people with at least one measurement record outside a valid observation period,Proportion,Number of people with a measurement record outside a valid observation period,Number of people in measurement,,,0,Observation Period
 1832,0,,Proportion of measurement records outside a valid observation period,Proportion,Number of records in measurement outside a valid observation period,Number of measurement records,,,0,Observation Period
 1833,0,,Proportion of measurement records inside a valid observation period and without a value,measurement_concept_id,Number of measurement records with no value for the given measurement_concept_id,proportion,,,0,Measurement
+1840,0,,"Number of persons with at least one measurement occurrence, by measurement_source_concept_id",measurement_source_concept_id,,,,,1,Measurement
 1891,0,,Percentage of total persons that have at least x measurements,measurement_concept_id,measurement_person,,,,1,Measurement
 1900,0,,"Source values mapped to concept_id 0 by table, by column, by source_value",table_name,column_name,source_value,,,1,Completeness
 2000,0,,Number of patients with at least 1 Dx and 1 Rx,,,,,,1,Completeness
@@ -290,6 +298,7 @@ ANALYSIS_ID,DISTRIBUTION,DISTRIBUTED_FIELD,ANALYSIS_NAME,STRATUM_1_NAME,STRATUM_
 2130,0,,Number of device_exposure records inside a valid observation period,,,,,,0,Observation Period
 2131,0,,Proportion of people with at least one device_exposure record outside a valid observation period,Proportion,Number of people with a device_exposure record outside a valid observation period,Number of people in device_exposure,,,0,Observation Period
 2132,0,,Proportion of device_exposure records outside a valid observation period,Proportion,Number of records in device_exposure outside a valid observation period,Number of device_exposure records,,,0,Observation Period
+2140,0,,"Number of persons with at least one device exposure, by device_source_concept_id",device_source_concept_id,,,,,1,Completeness
 2191,0,,Percentage of total persons that have at least x device exposures,device_concept_id,device_person,,,,1,Device Exposure
 2200,0,,Number of persons with at least one note by  note_type_concept_id,note_type_concept_id,,,,,1,Note
 2201,0,,"Number of note records, by note_type_concept_id",note_type_concept_id,,,,,1,Note

--- a/inst/sql/sql_server/analyses/1340.sql
+++ b/inst/sql/sql_server/analyses/1340.sql
@@ -1,0 +1,27 @@
+-- 1340	Number of persons with at least one visit detail, by visit_detail_source_concept_id
+-- restricted to visits overlapping with observation period
+
+--HINT DISTRIBUTE_ON_KEY(stratum_1)
+SELECT 
+	1340 AS analysis_id,
+	CAST(vd.visit_detail_source_concept_id AS VARCHAR(255)) AS stratum_1,
+	CAST(NULL AS VARCHAR(255)) AS stratum_2,
+	CAST(NULL AS VARCHAR(255)) AS stratum_3,
+	CAST(NULL AS VARCHAR(255)) AS stratum_4,
+	CAST(NULL AS VARCHAR(255)) AS stratum_5,
+	COUNT_BIG(DISTINCT vd.person_id) AS count_value
+INTO 
+	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_1340
+FROM
+	@cdmDatabaseSchema.visit_detail vd
+JOIN 
+    @cdmDatabaseSchema.observation_period op 
+ON 
+	vd.person_id = op.person_id
+AND	
+	vd.visit_detail_start_date >= op.observation_period_start_date  
+AND 
+	vd.visit_detail_start_date <= op.observation_period_end_date
+GROUP BY 
+	vd.visit_detail_source_concept_id
+;

--- a/inst/sql/sql_server/analyses/1840.sql
+++ b/inst/sql/sql_server/analyses/1840.sql
@@ -1,0 +1,25 @@
+-- 1840	Number of persons with at least one measurement occurrence, by measurement_source_concept_id
+
+--HINT DISTRIBUTE_ON_KEY(stratum_1)
+SELECT 
+	1840 AS analysis_id,
+	CAST(m.measurement_source_concept_id AS VARCHAR(255)) AS stratum_1,
+	CAST(NULL AS VARCHAR(255)) AS stratum_2,
+	CAST(NULL AS VARCHAR(255)) AS stratum_3,
+	CAST(NULL AS VARCHAR(255)) AS stratum_4,
+	CAST(NULL AS VARCHAR(255)) AS stratum_5,
+	COUNT_BIG(DISTINCT m.person_id) AS count_value
+INTO 
+	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_1840
+FROM 
+	@cdmDatabaseSchema.measurement m
+JOIN 
+	@cdmDatabaseSchema.observation_period op 
+ON 
+	m.person_id = op.person_id
+AND 
+	m.measurement_date >= op.observation_period_start_date
+AND 
+	m.measurement_date <= op.observation_period_end_date	
+GROUP BY 
+	m.measurement_source_concept_id;

--- a/inst/sql/sql_server/analyses/2140.sql
+++ b/inst/sql/sql_server/analyses/2140.sql
@@ -1,0 +1,25 @@
+-- 2140	Number of persons with at least one device exposure , by device_source_concept_id
+
+--HINT DISTRIBUTE_ON_KEY(stratum_1)
+SELECT 
+	2140 AS analysis_id,
+	CAST(de.device_source_concept_id AS VARCHAR(255)) AS stratum_1,
+	CAST(NULL AS VARCHAR(255)) AS stratum_2,
+	CAST(NULL AS VARCHAR(255)) AS stratum_3,
+	CAST(NULL AS VARCHAR(255)) AS stratum_4,
+	CAST(NULL AS VARCHAR(255)) AS stratum_5,
+	COUNT_BIG(DISTINCT de.person_id) AS count_value
+INTO 
+	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_2140
+FROM 
+	@cdmDatabaseSchema.device_exposure de
+JOIN 
+	@cdmDatabaseSchema.observation_period op 
+ON 
+	de.person_id = op.person_id
+AND 
+	de.device_exposure_start_date >= op.observation_period_start_date
+AND 
+	de.device_exposure_start_date <= op.observation_period_end_date		
+GROUP BY 
+	de.device_source_concept_id;

--- a/inst/sql/sql_server/analyses/240.sql
+++ b/inst/sql/sql_server/analyses/240.sql
@@ -1,0 +1,26 @@
+-- 240	Number of persons with at least one visit occurrence, by visit_source_concept_id
+-- restricted to visits overlapping with observation period
+
+--HINT DISTRIBUTE_ON_KEY(stratum_1)
+SELECT 
+	240 AS analysis_id,
+	CAST(vo.visit_source_concept_id AS VARCHAR(255)) AS stratum_1,
+	CAST(NULL AS VARCHAR(255)) AS stratum_2,
+	CAST(NULL AS VARCHAR(255)) AS stratum_3,
+	CAST(NULL AS VARCHAR(255)) AS stratum_4,
+	CAST(NULL AS VARCHAR(255)) AS stratum_5,
+	COUNT_BIG(DISTINCT vo.person_id) AS count_value
+INTO 
+	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_240
+FROM 
+	@cdmDatabaseSchema.visit_occurrence vo
+JOIN 
+	@cdmDatabaseSchema.observation_period op 
+ON 
+	vo.person_id = op.person_id
+AND 
+	vo.visit_start_date >= op.observation_period_start_date
+AND 
+	vo.visit_start_date <= op.observation_period_end_date
+GROUP BY 
+	vo.visit_source_concept_id;

--- a/inst/sql/sql_server/analyses/440.sql
+++ b/inst/sql/sql_server/analyses/440.sql
@@ -1,0 +1,25 @@
+-- 440	Number of persons with at least one condition occurrence, by condition_source_concept_id
+
+--HINT DISTRIBUTE_ON_KEY(stratum_1)
+SELECT 
+	440 AS analysis_id,
+	CAST(co.condition_source_concept_id AS VARCHAR(255)) AS stratum_1,
+	CAST(NULL AS VARCHAR(255)) AS stratum_2,
+	CAST(NULL AS VARCHAR(255)) AS stratum_3,
+	CAST(NULL AS VARCHAR(255)) AS stratum_4,
+	CAST(NULL AS VARCHAR(255)) AS stratum_5,
+	COUNT_BIG(DISTINCT co.person_id) AS count_value
+INTO 
+	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_440
+FROM 
+	@cdmDatabaseSchema.condition_occurrence co
+JOIN 
+	@cdmDatabaseSchema.observation_period op 
+ON 
+	co.person_id = op.person_id
+AND 
+	co.condition_start_date >= op.observation_period_start_date
+AND 
+	co.condition_start_date <= op.observation_period_end_date
+GROUP BY 
+	co.condition_source_concept_id;

--- a/inst/sql/sql_server/analyses/540.sql
+++ b/inst/sql/sql_server/analyses/540.sql
@@ -1,0 +1,25 @@
+-- 540	Number of persons with death, by cause_source_concept_id
+
+--HINT DISTRIBUTE_ON_KEY(stratum_1)
+SELECT 
+	540 AS analysis_id,
+	CAST(d.cause_source_concept_id AS VARCHAR(255)) AS stratum_1,
+	CAST(NULL AS VARCHAR(255)) AS stratum_2,
+	CAST(NULL AS VARCHAR(255)) AS stratum_3,
+	CAST(NULL AS VARCHAR(255)) AS stratum_4,
+	CAST(NULL AS VARCHAR(255)) AS stratum_5,
+	COUNT_BIG(DISTINCT d.person_id) AS count_value
+INTO 
+	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_540
+FROM 
+	@cdmDatabaseSchema.death d
+JOIN 
+	@cdmDatabaseSchema.observation_period op 
+ON 
+	d.person_id = op.person_id
+AND 
+	d.death_date >= op.observation_period_start_date
+AND 
+	d.death_date <= op.observation_period_end_date	
+GROUP BY 
+	d.cause_source_concept_id;

--- a/inst/sql/sql_server/analyses/640.sql
+++ b/inst/sql/sql_server/analyses/640.sql
@@ -1,0 +1,25 @@
+-- 640	Number of persons with at least one procedure occurrence, by procedure_source_concept_id
+
+--HINT DISTRIBUTE_ON_KEY(stratum_1)
+SELECT 
+	640 AS analysis_id,
+	CAST(po.procedure_source_concept_id AS VARCHAR(255)) AS stratum_1,
+	CAST(NULL AS VARCHAR(255)) AS stratum_2,
+	CAST(NULL AS VARCHAR(255)) AS stratum_3,
+	CAST(NULL AS VARCHAR(255)) AS stratum_4,
+	CAST(NULL AS VARCHAR(255)) AS stratum_5,
+	COUNT_BIG(DISTINCT po.person_id) AS count_value
+INTO 
+	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_640
+FROM 
+	@cdmDatabaseSchema.procedure_occurrence po
+JOIN 
+	@cdmDatabaseSchema.observation_period op 
+ON 
+	po.person_id = op.person_id
+AND 
+	po.procedure_date >= op.observation_period_start_date
+AND 
+	po.procedure_date <= op.observation_period_end_date
+GROUP BY 
+	po.procedure_source_concept_id;

--- a/inst/sql/sql_server/analyses/740.sql
+++ b/inst/sql/sql_server/analyses/740.sql
@@ -1,0 +1,25 @@
+-- 740	Number of persons with at least one drug occurrence, by drug_source_concept_id
+
+--HINT DISTRIBUTE_ON_KEY(stratum_1)
+SELECT 
+	740 AS analysis_id,
+	CAST(de.drug_source_concept_id AS VARCHAR(255)) AS stratum_1,
+	CAST(NULL AS VARCHAR(255)) AS stratum_2,
+	CAST(NULL AS VARCHAR(255)) AS stratum_3,
+	CAST(NULL AS VARCHAR(255)) AS stratum_4,
+	CAST(NULL AS VARCHAR(255)) AS stratum_5,
+	COUNT_BIG(DISTINCT de.person_id) AS count_value
+INTO 
+	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_740
+FROM 
+	@cdmDatabaseSchema.drug_exposure de
+JOIN 
+	@cdmDatabaseSchema.observation_period op 
+ON 
+	de.person_id = op.person_id
+AND 
+	de.drug_exposure_start_date >= op.observation_period_start_date
+AND 
+	de.drug_exposure_start_date <= op.observation_period_end_date
+GROUP BY 
+	de.drug_source_concept_id;

--- a/inst/sql/sql_server/analyses/840.sql
+++ b/inst/sql/sql_server/analyses/840.sql
@@ -1,0 +1,25 @@
+-- 840	Number of persons with at least one observation occurrence, by observation_source_concept_id
+
+--HINT DISTRIBUTE_ON_KEY(stratum_1)
+SELECT 
+	840 AS analysis_id,
+	CAST(o.observation_source_concept_id AS VARCHAR(255)) AS stratum_1,
+	CAST(NULL AS VARCHAR(255)) AS stratum_2,
+	CAST(NULL AS VARCHAR(255)) AS stratum_3,
+	CAST(NULL AS VARCHAR(255)) AS stratum_4,
+	CAST(NULL AS VARCHAR(255)) AS stratum_5,
+	COUNT_BIG(DISTINCT o.person_id) AS count_value
+INTO 
+	@scratchDatabaseSchema@schemaDelim@tempAchillesPrefix_840
+FROM 
+	@cdmDatabaseSchema.observation o
+JOIN 
+	@cdmDatabaseSchema.observation_period op 
+ON 
+	o.person_id = op.person_id
+AND 
+	o.observation_date >= op.observation_period_start_date
+AND 
+	o.observation_date <= op.observation_period_end_date
+GROUP BY 
+	o.observation_source_concept_id;


### PR DESCRIPTION
The `achilles_analysis_details.csv` contains now the non-standard codes person count analysis ids.

9 SQL files are added which are as follows

240,  440, 540,  640, 740, 840, 1340, 1840, 2140
| Analysis ID | Table | Description |
| ------------ | --------- | ------------ |
| 240   | Visit Occurrence | Number of persons with at least one visit occurrence, by visit_source_concept_id |
| 440   | Condition Occurrence | Number of persons with at least one condition occurrence, by condition_source_concept_id |
| 540   | Death | Number of persons with death, by cause_source_concept_id |
| 640   | Procedure Occurrence | Number of persons with at least one procedure occurrence, by procedure_source_concept_id |
| 740   | Drug Exposure | Number of persons with at least one drug exposure, by drug_source_concept_id |
| 840   | Observation | Number of persons with at least one observation occurrence, by observation_source_concept_id |
| 1340 | Visit Detail | Number of persons with at least one visit detail, by visit_detail_source_concept_id |
| 1840 | Measurement | Number of persons with at least one measurement occurrence, by measurement_source_concept_id |
| 2140 | Device Exposure | Number of persons with at least one device exposure, by device_source_concept_id |
